### PR TITLE
Also link to main kiwi ruby page in 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -55,7 +55,7 @@
 <body>
     <h1>Page Not Found</h1>
     <p>Sorry, but the page you were trying to view does not exist.</p>
-    <p>You might be able to find it on <a href="https://2017-kiwi.ruby.nz">the 2017 edition of Kiwi Ruby</a>.</p>
+    <p><a href="https://kiwi.ruby.nz">Head back to the main page</a>, or you might be able to find what you're looking for on <a href="https://2017-kiwi.ruby.nz">the 2017 edition of Kiwi Ruby</a>.</p>
 </body>
 </html>
 <!-- IE needs 512+ bytes: https://blogs.msdn.microsoft.com/ieinternals/2010/08/18/friendly-http-error-pages/ -->


### PR DESCRIPTION
Currently if you google for kiwi ruby, the old pages show up: 

<img width="665" alt="Screen Shot 2019-07-26 at 1 42 24 PM" src="https://user-images.githubusercontent.com/1615322/61919787-3d0c5e80-afab-11e9-8679-23fa29547a3a.png">

So it's probably worth also having a link to this year's website