### PR TITLE
Remove cfp link

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,14 +89,7 @@
         <div  class="kr-content_inner">
 
           <h3 class="kr-details_title u-mt-10 u-mb-0 u-viewable--large"><strong>1st of November 2019</strong></h3>
-          <p class="u-mt-10 u-viewable--large">More details on the way</p>
-          <h2 class="kr-details_title u-mt-35 u-mb-0">Call for Papers</h2>
-          <p class="u-mt-10">
-            Would you like to be a speaker at <strong>Kiwi&nbsp;Ruby 2019</strong>?
-            We're accepting proposals for presentations until <strong>July 31st, 11:59pm</strong> NZ time.
-          </p>
-          <a class="kr-btn" href="https://papercall.io/kiwi-ruby-2019" target="_blank"><span>Submit your proposal here</span></a>
-
+          <p class="u-mt-10 u-viewable--large">Te Papa, Wellington</p>
         </div>
       </div>
       <div class="column column--6">
@@ -126,7 +119,7 @@
     <hr class="u-rule--ruby">
   </section>
   <section class="kr-content kr-content--sponsors u-wrapper-margins">
-    <div class="row row--narrow">    
+    <div class="row row--narrow">
       <div  class="kr-content_inner--sponsor">
         <h2 class="kr-content_title kr-content_title--sponsor">Kiwi Ruby wouldn't be possible without<br class="u-viewable--x-large"> the support of our friends.</h2>
       </div>
@@ -139,7 +132,7 @@
     <div class="row row--narrow u-mt-30">
       <div  class="kr-content_inner--sponsor row row--small-column ">
         <div class="column column--3">
-          <a href="https://fluxfederation.com" class="kr-sponsor-logo_link" target="_blank">  
+          <a href="https://fluxfederation.com" class="kr-sponsor-logo_link" target="_blank">
             <img src="img/sponsors/logo-flux.png" class="kr-sponsor-logo"/>
           </a>
         </div>


### PR DESCRIPTION
Remove the link to CFP (as it has closed) and also mention the venue

<details>
<summary>Screenshot</summary>

<img width="1227" alt="Screen Shot 2019-08-07 at 6 02 25 PM" src="https://user-images.githubusercontent.com/1615322/62598456-89f21c80-b93d-11e9-98ea-ab5f3073b521.png">

</details>
